### PR TITLE
Replace phpdbg with php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## Summary
- replace `-p phpdbg` with `-p php` in the `coverage` Makefile target

## Motivation
- `phpdbg` should be removed from coverage targets in favor of the standard `php` binary
- relates to contributte/contributte#73

## Testing
- [x] `make -n coverage`
- [ ] Full test suite
- [ ] CI passes