### PR TITLE
Composer: require PHP >=8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "type": "project",
   "require": {
-    "php": "^8.4",
+    "php": ">=8.4",
     "contributte/kernel": "^0.2.0",
     "contributte/framex": "^0.3.0",
     "contributte/utils": "^0.7.0"


### PR DESCRIPTION
Updates the PHP requirement in composer.json from ^8.4 to >=8.4.